### PR TITLE
Add Baevsky Stress Index Calculation to heartpy.py

### DIFF
--- a/heartpy/heartpy.py
+++ b/heartpy/heartpy.py
@@ -10,6 +10,7 @@ import sys
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 from scipy.signal import butter, filtfilt, welch, periodogram, resample_poly, resample
+from statistics import mode
 
 from . import exceptions
 from .datautils import get_data, get_samplerate_mstimer, get_samplerate_datetime,\
@@ -294,7 +295,24 @@ include an index column?'
                                          desired_sample_rate=high_precision_fs, working_data=working_data)
 
     working_data = calc_rr(working_data['peaklist'], sample_rate, working_data=working_data)
+    
+    # Obtain Mode
+    mode_v = mode(working_data['RR_list'])
+    measures['Mo'] = mode_v
 
+    # Obtain AMo (mode amplitude %)
+    amo = np.max(working_data['RR_list']) - np.min(working_data['RR_list'])
+    measures['AMo'] = amo
+
+    # Obtain VR (variational range)
+    num_mode = np.count_nonzero(working_data['RR_list'] == mode_v)
+    vr = (num_mode/len(working_data['RR_list']))*100
+    measures['VR'] = vr
+
+    # Calculate Baevsky Stress Index
+    si = (amo/(2*vr*mode_v)) * 100
+    measures['SI'] = si
+    
     working_data = check_peaks(working_data['RR_list'], working_data['peaklist'], working_data['ybeat'],
                                reject_segmentwise, working_data=working_data)
 


### PR DESCRIPTION
Added the Baevsky Stress index calculation to measures with the corresponding building blocks of the main formula:

si = AMo / (2 * VR * Mo)
where
R-R interval - the time delay between consecutive heartbeats (assumed to be the inverse value of the bpm)
Mo - mode - most frequent R-R interval value
AMo - mode amplitude - % of the intervals corresponding to Mode
VR - variational range - the difference  between min and max R-R intervals

Reference: http://www.cardiometry.net/issues/no10-may-2017/heart-rate-variability-analysis